### PR TITLE
Add simple Firebase planner web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # Planner
+
+A tiny Firebase-backed planner that lets anyone capture tasks with due dates and keep them in sync across devices.
+
+## Features
+
+- Minimal form to capture a task title, optional details, and due date/time.
+- Real-time updates powered by Cloud Firestore so every session stays in sync.
+- Mark tasks as complete or delete them with a single click.
+- Simple, responsive layout that works well on desktop and mobile.
+
+## Prerequisites
+
+1. A Firebase project with Cloud Firestore enabled.
+2. A web app registered in that Firebase project.
+
+## Getting started
+
+1. **Clone this repository** and install a simple static server if you don't already have one.
+
+   ```bash
+   git clone <this repo>
+   cd Planner
+   npm install --global serve # or use any static server you prefer
+   ```
+
+2. **Create a Firestore database** in test mode for quick prototyping, or production mode if you're ready to enforce security rules. The app uses a single `tasks` collection.
+
+3. **Grab your Firebase web config** from the Firebase console (Project settings → General → Your apps) and paste it into the JSON block inside `public/index.html`, replacing the placeholder values.
+
+   ```html
+   <script id="firebase-config" type="application/json">
+     {
+       "apiKey": "...",
+       "authDomain": "...",
+       "projectId": "...",
+       "storageBucket": "...",
+       "messagingSenderId": "...",
+       "appId": "..."
+     }
+   </script>
+   ```
+
+4. **Run the app locally.**
+
+   ```bash
+   serve public
+   ```
+
+   Then open the printed URL (for example `http://localhost:3000`) in your browser. Adding, completing, and deleting tasks will reflect in Firestore instantly.
+
+## Deployment
+
+Any static hosting solution works (Firebase Hosting, Netlify, Vercel, GitHub Pages, etc.). Upload the `public` directory and ensure the Firebase configuration matches the deployed environment.
+
+## Next steps
+
+- Add Firebase Authentication if you want to limit access to each user's tasks.
+- Customize Firestore security rules to restrict who can create or modify tasks.
+- Extend the data model with reminders, categories, or recurring tasks.

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,194 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  doc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  Timestamp,
+  onSnapshot,
+  query,
+  orderBy,
+} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+const configElement = document.getElementById("firebase-config");
+let firebaseConfig;
+try {
+  firebaseConfig = JSON.parse(configElement.textContent);
+} catch (error) {
+  renderError("The Firebase configuration block is missing or malformed.");
+  throw error;
+}
+
+const missingConfig = Object.values(firebaseConfig).some((value) =>
+  typeof value === "string" ? value.startsWith("YOUR_") : !value
+);
+
+if (missingConfig) {
+  renderError(
+    "Update the Firebase configuration inside index.html before using the planner."
+  );
+  throw new Error("Firebase configuration not provided");
+}
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const tasksCollection = collection(db, "tasks");
+
+const taskForm = document.getElementById("task-form");
+const taskList = document.getElementById("task-list");
+const emptyState = document.getElementById("empty-state");
+
+function renderError(message) {
+  const container = document.createElement("div");
+  container.className = "empty";
+  container.textContent = message;
+  document.querySelector(".app__tasks").appendChild(container);
+}
+
+function formatDueDate(task) {
+  if (!task.dueAt) {
+    return "No due date";
+  }
+
+  const date = task.dueAt instanceof Timestamp ? task.dueAt.toDate() : task.dueAt;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: task.timeProvided ? "short" : undefined,
+  }).format(date);
+}
+
+function renderTasks(tasks) {
+  taskList.innerHTML = "";
+
+  if (!tasks.length) {
+    emptyState.hidden = false;
+    return;
+  }
+
+  emptyState.hidden = true;
+
+  for (const task of tasks) {
+    const li = document.createElement("li");
+    li.className = `task${task.completed ? " task--complete" : ""}`;
+
+    const top = document.createElement("div");
+    top.className = "task__top";
+
+    const title = document.createElement("h3");
+    title.className = "task__title";
+    title.textContent = task.title;
+    top.appendChild(title);
+
+    const actions = document.createElement("div");
+    actions.className = "task__actions";
+
+    const toggle = document.createElement("button");
+    toggle.type = "button";
+    toggle.textContent = task.completed ? "Mark active" : "Mark done";
+    toggle.addEventListener("click", () => toggleTask(task));
+    actions.appendChild(toggle);
+
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.textContent = "Delete";
+    remove.addEventListener("click", () => deleteTask(task));
+    actions.appendChild(remove);
+
+    top.appendChild(actions);
+    li.appendChild(top);
+
+    if (task.details) {
+      const details = document.createElement("p");
+      details.textContent = task.details;
+      li.appendChild(details);
+    }
+
+    const meta = document.createElement("div");
+    meta.className = "task__meta";
+    meta.innerHTML = `<span>${formatDueDate(task)}</span>`;
+    li.appendChild(meta);
+
+    taskList.appendChild(li);
+  }
+}
+
+function toTimestamp(dateValue, timeValue) {
+  if (!dateValue) {
+    return { dueAt: null, timeProvided: false };
+  }
+
+  const isoString = `${dateValue}T${timeValue || "00:00"}`;
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return { dueAt: null, timeProvided: false };
+  }
+
+  return { dueAt: Timestamp.fromDate(date), timeProvided: Boolean(timeValue) };
+}
+
+taskForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const formData = new FormData(taskForm);
+
+  const title = formData.get("title").trim();
+  const details = formData.get("details").trim();
+  const dateValue = formData.get("date");
+  const timeValue = formData.get("time");
+
+  if (!title) {
+    return;
+  }
+
+  const { dueAt, timeProvided } = toTimestamp(dateValue, timeValue);
+
+  await addDoc(tasksCollection, {
+    title,
+    details,
+    completed: false,
+    dueAt,
+    timeProvided,
+    createdAt: serverTimestamp(),
+  });
+
+  taskForm.reset();
+  taskForm.title.focus();
+});
+
+function toggleTask(task) {
+  const reference = doc(tasksCollection, task.id);
+  updateDoc(reference, { completed: !task.completed });
+}
+
+function deleteTask(task) {
+  const reference = doc(tasksCollection, task.id);
+  deleteDoc(reference);
+}
+
+const tasksQuery = query(tasksCollection, orderBy("dueAt"), orderBy("createdAt"));
+
+onSnapshot(tasksQuery, (snapshot) => {
+  const tasks = snapshot.docs.map((docSnapshot) => ({
+    id: docSnapshot.id,
+    ...docSnapshot.data(),
+  }));
+
+  tasks.sort((a, b) => {
+    if (a.completed !== b.completed) {
+      return a.completed ? 1 : -1;
+    }
+
+    const aTime = a.dueAt instanceof Timestamp ? a.dueAt.toMillis() : 0;
+    const bTime = b.dueAt instanceof Timestamp ? b.dueAt.toMillis() : 0;
+
+    if (aTime !== bTime) {
+      return aTime - bTime;
+    }
+
+    return (a.createdAt?.seconds || 0) - (b.createdAt?.seconds || 0);
+  });
+
+  renderTasks(tasks);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple Planner</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>Simple Planner</h1>
+        <p>Plan your day and keep everything in sync with Firebase.</p>
+      </header>
+
+      <section class="app__form">
+        <form id="task-form">
+          <div class="field">
+            <label for="title">Title</label>
+            <input id="title" name="title" type="text" placeholder="What do you need to do?" required />
+          </div>
+
+          <div class="field">
+            <label for="details">Details</label>
+            <textarea id="details" name="details" rows="3" placeholder="Add any notes"></textarea>
+          </div>
+
+          <div class="field field--inline">
+            <div>
+              <label for="date">Due date</label>
+              <input id="date" name="date" type="date" />
+            </div>
+            <div>
+              <label for="time">Time</label>
+              <input id="time" name="time" type="time" />
+            </div>
+          </div>
+
+          <button type="submit" class="primary">Add task</button>
+        </form>
+      </section>
+
+      <section class="app__tasks">
+        <h2>Upcoming tasks</h2>
+        <ul id="task-list"></ul>
+        <p id="empty-state" class="empty">Add a task to get started.</p>
+      </section>
+    </main>
+
+    <script id="firebase-config" type="application/json">
+      {
+        "apiKey": "YOUR_API_KEY",
+        "authDomain": "YOUR_AUTH_DOMAIN",
+        "projectId": "YOUR_PROJECT_ID",
+        "storageBucket": "YOUR_STORAGE_BUCKET",
+        "messagingSenderId": "YOUR_MESSAGING_SENDER_ID",
+        "appId": "YOUR_APP_ID"
+      }
+    </script>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,183 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f4f5fb;
+  color: #1d1e30;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  background: radial-gradient(circle at top, #fff 0%, #f4f5fb 60%, #e7e8f3 100%);
+}
+
+.app {
+  max-width: 720px;
+  width: min(720px, 90vw);
+  margin: 3rem auto;
+  padding: 2.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 30px 60px rgba(31, 45, 61, 0.12);
+  border-radius: 24px;
+  display: grid;
+  gap: 2rem;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.app__header p {
+  margin: 0;
+  color: #5a6072;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field--inline {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.field--inline > div {
+  flex: 1;
+  min-width: 160px;
+}
+
+label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #394359;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #ccd3e0;
+  background: #f9faff;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus {
+  outline: 2px solid #7c9bff;
+  outline-offset: 2px;
+}
+
+button.primary {
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #5f6fff, #7a9cff);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  box-shadow: 0 15px 30px rgba(95, 111, 255, 0.25);
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(95, 111, 255, 0.32);
+}
+
+.app__tasks ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.task {
+  padding: 1.2rem 1.5rem;
+  background: white;
+  border-radius: 18px;
+  box-shadow: 0 12px 24px rgba(31, 45, 61, 0.1);
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid transparent;
+}
+
+.task--complete {
+  border-color: #9bc778;
+  opacity: 0.8;
+}
+
+.task__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.task__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.task__meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #5a6072;
+}
+
+.task__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.task__actions button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: none;
+  background: #edf1ff;
+  color: #344054;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.task__actions button:hover {
+  background: #dce4ff;
+}
+
+.empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  color: #7f8ba7;
+  background: #f1f3fb;
+  border-radius: 16px;
+}
+
+@media (max-width: 640px) {
+  .app {
+    margin: 1.5rem auto;
+    padding: 1.75rem;
+  }
+
+  .task__top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .task__actions {
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static planner UI with task form and task list
- wire the interface to Firebase Cloud Firestore for real-time tasks
- document setup instructions for providing Firebase config and running locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deebcecdd0832e8ce7f982f7c94ef7